### PR TITLE
Changed create packages target to do ILMerge before creating nuget for fspec-runner

### DIFF
--- a/FSpec.AutoFoq/FSpec.AutoFoq.fsproj
+++ b/FSpec.AutoFoq/FSpec.AutoFoq.fsproj
@@ -27,10 +27,10 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <Tailcalls>true</Tailcalls>
-    <OutputPath>..\output\Release\</OutputPath>
+    <OutputPath>..\output\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <WarningLevel>3</WarningLevel>
-    <DocumentationFile>..\output\Release\FSpec.AutoFoq.XML</DocumentationFile>
+    <DocumentationFile>..\output\FSpec.AutoFoq.XML</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup>
     <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>

--- a/FSpec.Extras.SelfTests/FSpec.Extras.SelfTests.fsproj
+++ b/FSpec.Extras.SelfTests/FSpec.Extras.SelfTests.fsproj
@@ -27,10 +27,10 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <Tailcalls>true</Tailcalls>
-    <OutputPath>..\output\Release\</OutputPath>
+    <OutputPath>..\output\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <WarningLevel>3</WarningLevel>
-    <DocumentationFile>..\output\Release\FSpec.Extras.SelfTests.XML</DocumentationFile>
+    <DocumentationFile>..\output\FSpec.Extras.SelfTests.XML</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup>
     <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
@@ -65,6 +65,9 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="mscorlib" />
+    <Reference Include="Ninject">
+      <HintPath>..\packages\Ninject\lib\net40\Ninject.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Numerics" />

--- a/FSpec.MbUnitWrapper/FSpec.MbUnitWrapper.fsproj
+++ b/FSpec.MbUnitWrapper/FSpec.MbUnitWrapper.fsproj
@@ -27,10 +27,10 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <Tailcalls>true</Tailcalls>
-    <OutputPath>..\output\Release\</OutputPath>
+    <OutputPath>..\output\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <WarningLevel>3</WarningLevel>
-    <DocumentationFile>..\output\Release\FSpec.MbUnitWrapper.XML</DocumentationFile>
+    <DocumentationFile>..\output\FSpec.MbUnitWrapper.XML</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup>
     <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>

--- a/cli/FSpec.Runner.fsproj
+++ b/cli/FSpec.Runner.fsproj
@@ -31,11 +31,11 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <Tailcalls>true</Tailcalls>
-    <OutputPath>..\output\Release\</OutputPath>
+    <OutputPath>..\output\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <WarningLevel>3</WarningLevel>
     <PlatformTarget>AnyCPU</PlatformTarget>
-    <DocumentationFile>..\output\Release\fspec.cli.XML</DocumentationFile>
+    <DocumentationFile>..\output\fspec.cli.XML</DocumentationFile>
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>

--- a/core/FSpec.fsproj
+++ b/core/FSpec.fsproj
@@ -27,10 +27,10 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <Tailcalls>true</Tailcalls>
-    <OutputPath>..\output\Release\</OutputPath>
+    <OutputPath>..\output\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <WarningLevel>3</WarningLevel>
-    <DocumentationFile>..\output\Release\fspec.XML</DocumentationFile>
+    <DocumentationFile>..\output\fspec.XML</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup>
     <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>

--- a/fspec.nuspec
+++ b/fspec.nuspec
@@ -22,6 +22,6 @@
   </metadata>
   <files>
     <file src="output/FSpec.dll" target="lib/net40/FSpec.dll" />
-    <file src="output/FSpec-runner.exe" target="tools/FSpec-runner.exe" />
+    <file src="output/FSpec-runner-merged.exe" target="tools/FSpec-runner.exe" />
   </files>
 </package>

--- a/fspec.sln
+++ b/fspec.sln
@@ -1,4 +1,3 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
 VisualStudioVersion = 12.0.31101.0
@@ -20,6 +19,11 @@ EndProject
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "FSpec.MbUnitWrapper", "FSpec.MbUnitWrapper\FSpec.MbUnitWrapper.fsproj", "{C5C98D42-1FFC-40AC-AC07-A9184ACC2A7D}"
 EndProject
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "FSpec.Extras.SelfTests", "FSpec.Extras.SelfTests\FSpec.Extras.SelfTests.fsproj", "{0381ACB6-20E2-434F-8832-B037E2716181}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Build", "Build", "{019CF3D5-63B1-401B-B1CD-4413FCDE8151}"
+	ProjectSection(SolutionItems) = preProject
+		build.fsx = build.fsx
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -5,3 +5,4 @@ nuget mbunit
 nuget Ninject
 nuget Ninject.MockingKernel
 nuget CommandLineParser
+nuget ilmerge

--- a/paket.lock
+++ b/paket.lock
@@ -3,7 +3,8 @@ NUGET
   specs:
     CommandLineParser (1.9.71)
     Foq (1.6)
+    ilmerge (2.14.1208)
     mbunit (3.4.14.0)
     Ninject (3.2.2.0)
     Ninject.MockingKernel (3.2.1.0)
-      Ninject (>= 3.2.0.0 <  3.3.0.0)
+      Ninject (>= 3.2.0.0 < 3.3.0.0)


### PR DESCRIPTION
In Summary:

* Changed 'CreatePackage' in build.fsx to run ilmerge before creating the package
* Changed build fsx to use Fake build instead of calling rake
* Added Ninject dependency to MbUNitWrapper in order to build in release
* Changed all fs projects to build to ./output in release
* Changed nuspec to refer to fspec-runner-merged instead
* Added paket dependency to ilmerge